### PR TITLE
Add OWASP Kubernetes Top Ten source and project entry

### DIFF
--- a/data/skill_based_projects.md
+++ b/data/skill_based_projects.md
@@ -3,3 +3,4 @@
 | Skill | Project | Repo | Notes |
 | --- | --- | --- | --- |
 | _Kubernetes_ | _Example_ | https://github.com/example/project | _Docs or onboarding links_ |
+| Kubernetes Security | OWASP Kubernetes Top Ten | https://owasp.org/www-project-kubernetes-top-ten/ | OWASP project page with guidance and resources |

--- a/data/sources.md
+++ b/data/sources.md
@@ -9,3 +9,4 @@ Authoritative sources used or recommended for this repo.
 | Linux Foundation Mentorship | https://mentorship.lfx.linuxfoundation.org/ | Mentorship program listings |
 | LFX Mentorship API | https://api.mentorship.lfx.linuxfoundation.org/projects | Used to scrape CNCF mentorships |
 | CNCF GitHub Orgs | https://github.com/cncf | Official GitHub org |
+| OWASP Kubernetes Top Ten | https://owasp.org/www-project-kubernetes-top-ten/ | Kubernetes security guidance |


### PR DESCRIPTION
This PR change is to add OWASP Top 10 project info to the open source project list.